### PR TITLE
Use fs.existsSync if available

### DIFF
--- a/lib/bundled.js
+++ b/lib/bundled.js
@@ -1,8 +1,11 @@
-var path = require('path')
-  , _ = require('underscore')
+var _ = require('underscore')
   , async = require('async')
   , semver = require('semver')
-  ;
+  , path = require('path')
+  , fs = require('fs')
+  , existsSync
+
+existsSync = fs.existsSync || path.existsSync
 
 module.exports = function(app, options) {
 
@@ -97,10 +100,10 @@ module.exports = function(app, options) {
     var configPath = bundlePath + '/' + options.bundleConfig
       , bundle;
 
-    if (!path.existsSync(bundlePath)) {
+    if (!existsSync(bundlePath)) {
       throw new Error('Unable to find bundle: ' + bundlePath);
     }
-    if (!path.existsSync(configPath)) {
+    if (!existsSync(configPath)) {
       throw new Error('Unable to find bundle config: ' + configPath);
     }
 


### PR DESCRIPTION
Falls back to `path.existsSync` for 0.6.x compatibility (if that's even desirable).

This prevents the annoying "path.existsSync is now called 'fs.existsSync'" message in ctrl and catfish and any other projects that might depend on bundled.
